### PR TITLE
API.py: fix force bool

### DIFF
--- a/termux/API.py
+++ b/termux/API.py
@@ -43,7 +43,13 @@ def vibrate(duration: int = 1000, force: bool = False):
         Force vibrate even in silent mode, default = False
 
     '''
-    return execute(["termux-vibrate", "-d", duration])
+
+    command = ["termux-vibrate", "-d", duration]
+
+    if force:
+        command.append("-f")
+
+    return execute(command)
 
 
 def contactlist():


### PR DESCRIPTION
force flag isnt used, means, device wont force vibrate in silent mode, even if force=True. this commit fixes the issue.