### PR TITLE
fix Concatenation

### DIFF
--- a/termux/API.py
+++ b/termux/API.py
@@ -98,7 +98,7 @@ def volume(**kwargs):
       Valid audio streams are: alarm, music, notification, ring, system, call.
     volume: str (optional)
     '''
-    cmd = "termux-volume"
+    cmd = ["termux-volume"]
     if(len(kwargs) > 0):
         stream = "ring"; volume = "5"
         stream = kwargs.get('stream', 'ring')


### PR DESCRIPTION
### Concatenation Error

Here, **cmd** is a _string_, and there was an attempt to concatenate it with a _list_:
```python
cmd = "termux-volume"
    cmd += [stream, volume]
``` 
Which caused the following error:
```shell
TypeError: can only concatenate str (not "list") to str
``` 
This commit fixes the issue.