### PR TITLE
Fix: command to get telephony device information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="termux-api", 
-    version="1.2.5.3",
+    name="termux-api",
+    version="1.2.5.4",
     author="drshajul",
     author_email="drshajul@gmail.com",
     description="A package for accessing termux-api",

--- a/termux/Telephony.py
+++ b/termux/Telephony.py
@@ -3,7 +3,7 @@
 Avaliable methods are:
     call       - make a phone call to number (str)
     cellinfo   - retrieve cell information (json)
-    deviceinfo -
+    deviceinfo - retrieve telephony device information (json)
 '''
 
 from .android import execute
@@ -14,6 +14,9 @@ def __dir__():
 def call(phone_number: str):
     '''
     Makes a phone call to number passed as an argument
+    Parameters
+    ----------
+    phone_number: (str) : The phone number to call
     '''
     return execute(["termux-telephony-call", phone_number])
 
@@ -27,6 +30,6 @@ def cellinfo():
 
 def deviceinfo():
     '''
-    Get information about the telephony device. 
+    Get information about the telephony device.
     '''
-    return execute(["termux-telephony-displayinfo"])
+    return execute(["termux-telephony-deviceinfo"])


### PR DESCRIPTION
- Fixed a typo in the command used to retrieve telephony device information.

- The original command `termux-telephony-displayinfo` was incorrect and has been corrected to `termux-telephony-deviceinfo`.

- The function `deviceinfo()` has been updated to use the correct command.

**Updated Code:**
```python
def deviceinfo():
    return execute(["termux-telephony-deviceinfo"])
``` 
**Shell Command:**
```shell
termux-telephony-deviceinfo
``` 